### PR TITLE
add secure website module to example test configuration

### DIFF
--- a/.github/workflows/example-test.yml
+++ b/.github/workflows/example-test.yml
@@ -82,6 +82,13 @@ jobs:
           project_name        = "Production-Backups"
           owner               = "DevOps-Team"
         }
+
+        module "secure_website" {
+          source = "mikmorley/static-website/aws"
+
+          name        = "test-website""
+          environment = "production"
+        }
         EOF
 
     - name: Terraform Init


### PR DESCRIPTION
This pull request adds a new Terraform module to the GitHub Actions workflow for infrastructure provisioning. The module configures a secure static website as part of the deployment process.

Infrastructure provisioning:

* Added a `secure_website` Terraform module using the `mikmorley/static-website/aws` source, with the name set to `"test-website"` and the environment set to `"production"` in `.github/workflows/example-test.yml`.