### PR TITLE
fix: correct environment value case in secure website module

### DIFF
--- a/.github/workflows/example-test.yml
+++ b/.github/workflows/example-test.yml
@@ -87,7 +87,7 @@ jobs:
           source = "mikmorley/static-website/aws"
 
           name        = "test-website"
-          environment = "production"
+          environment = "Production"
         }
         EOF
 


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/example-test.yml` workflow file, correcting the value of the `environment` variable to use proper capitalization. This helps ensure consistency and may be required by downstream tooling.

- Changed the `environment` value from `"production"` to `"Production"` in the `jobs` section of `.github/workflows/example-test.yml`.